### PR TITLE
Add responsive for book details

### DIFF
--- a/scss/detail.scss
+++ b/scss/detail.scss
@@ -264,11 +264,11 @@ $lower-screen-width: calc(#{$book-badge-width} * 0.7);
   }
 
   .book-cover-page {
-    margin: 50px 0 0;
-    height: 570px;
-    width: 335px;
     flex-direction: column;
+    height: 570px;
+    margin: 50px 0 0;
     padding: 20px;
+    width: 335px;
 
     &::after {
       height: $lower-screen-height;
@@ -279,8 +279,8 @@ $lower-screen-width: calc(#{$book-badge-width} * 0.7);
   .book-img {
     align-self: center;
     height: 300px;
-    width: 210px;
     margin: 15px 0 0;
+    width: 210px;
   }
 
   .book-title {

--- a/scss/detail.scss
+++ b/scss/detail.scss
@@ -2,8 +2,8 @@
 
 $book-badge-height: 120px;
 $book-badge-width: 100px;
-$badge-mobile-height: calc(#{$book-badge-height} * (70/100));
-$badge-mobile-width: calc(#{$book-badge-width} * (70/100));
+$lower-screen-height: calc(#{$book-badge-height} * 0.7);
+$lower-screen-width: calc(#{$book-badge-width} * 0.7);
 
 * {
   font-family: Roboto;
@@ -45,8 +45,7 @@ $badge-mobile-width: calc(#{$book-badge-width} * (70/100));
   width: 900px;
   
   &::after {
-    background: url('images/badge.png') no-repeat;
-    background-size: 100%;
+    background: url('images/badge.png') center/100% no-repeat;
     content: '';
     height: $book-badge-height;
     left: 210px;
@@ -267,13 +266,13 @@ $badge-mobile-width: calc(#{$book-badge-width} * (70/100));
   .book-cover-page {
     margin: 50px 0 0;
     height: 570px;
-    width: 336px;
+    width: 335px;
     flex-direction: column;
     padding: 20px;
 
     &::after {
-      height: $badge-mobile-height;
-      width: $badge-mobile-width;
+      height: $lower-screen-height;
+      width: $lower-screen-width;
     }
   }
 
@@ -309,5 +308,4 @@ $badge-mobile-width: calc(#{$book-badge-width} * (70/100));
   .book-header{
     margin: 10px 0 20px;
   }
-  
 }

--- a/scss/detail.scss
+++ b/scss/detail.scss
@@ -1,4 +1,8 @@
 @import 'colors';
+$book-badge-height: 120px;
+$book-badge-width: 100px;
+$badge-mobile-height: calc(#{$book-badge-height} * (70/100));
+$badge-mobile-width: calc(#{$book-badge-width} * (70/100));
 
 * {
   font-family: Roboto;
@@ -41,12 +45,13 @@
   
   &::after {
     background: url('images/badge.png') no-repeat;
+    background-size: 100%;
     content: '';
-    height: 120px;
+    height: $book-badge-height;
     left: 210px;
     position: absolute;
     transform: rotate(1deg);
-    width: 100px;
+    width: $book-badge-width;
   }
 }
 
@@ -250,4 +255,58 @@
 .logo-wolox-login {
   height: 70px;
   width: 215px;
+}
+
+@media screen and (max-width: 1024px) {
+  .book-detail-container {
+    align-items: center;
+    flex-direction: column-reverse;
+  }
+
+  .book-cover-page {
+    margin: 50px 0 0;
+    height: 570px;
+    width: 336px;
+    flex-direction: column;
+    padding: 20px;
+
+    &::after {
+      height: $badge-mobile-height;
+      width: $badge-mobile-width;
+    }
+  }
+
+  .book-img {
+    align-self: center;
+    height: 300px;
+    width: 210px;
+    margin: 15px 0 0;
+  }
+
+  .book-title {
+    font-size: 25px;
+    margin: 20px 0;
+  }
+
+  .book-genre {
+    font-size: 15px;
+  }
+
+  .default-text {  
+    font-size: 14px;
+  }
+
+  .book-content-row {
+    margin: 0 0 15px;
+  }
+
+  .book-info {
+    flex: 1;
+    margin: 0;
+  }
+
+  .book-header{
+    margin: 10px 0 20px;
+  }
+  
 }

--- a/scss/detail.scss
+++ b/scss/detail.scss
@@ -1,4 +1,5 @@
 @import 'colors';
+
 $book-badge-height: 120px;
 $book-badge-width: 100px;
 $badge-mobile-height: calc(#{$book-badge-height} * (70/100));
@@ -257,7 +258,7 @@ $badge-mobile-width: calc(#{$book-badge-width} * (70/100));
   width: 215px;
 }
 
-@media screen and (max-width: 1024px) {
+@media only screen and (max-width: 1024px) {
   .book-detail-container {
     align-items: center;
     flex-direction: column-reverse;


### PR DESCRIPTION
## Summary 

This will add the responsive feature for adapt the book details for screens under 1024px, for this I had to change some margins, some heights and widths for the logo and the badge. Also, the badge needed to be 30% smaller than the original. So I made use of the CSS variables, and made that with the responsive, the badge image only is going to be a 70% of the original badge. (70/100)*total = 70% of the total. That's the way I used to make the badge adapt to the 30%. 

I fixed some useless margins and paddings too.

**New features**

- Add responsive feature
- Set all the detail with flex, variables, and responsive to be clear at a resolution under 1024px

## Screenshots 

![Screenshot from 2020-04-07 18-25-34](https://user-images.githubusercontent.com/29925817/78721461-faeb3900-78fd-11ea-9813-8db71ae34f53.png)



## Cards

https://trello.com/c/cJS7fUnd/34-responsive